### PR TITLE
Specify minimum build requirements by pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]


### PR DESCRIPTION
Dear developers of UVMultiFit, thank you for creating this great package! I am Akio Taniguchi, a postdoc who works at Astrophysics laboratory of Nagoya University, Japan. I recently found that the installation of UVMultiFit on a whole new Python environment failed by:

```plaintext
ModuleNotFoundError: No module named 'numpy'
```

This is because NumPy is used in `setup.py` but it is not available at the moment of the installation of UVMultiFit.

Here I would like to propose to specify minimum build requirements by `pyproject.toml` defined by [PEP 518](https://peps.python.org/pep-0518/). When running `pip install .`, this will install NumPy in an environment that is isolated only for the build process, so the issue can be avoided. Note that we still need to manually install the package dependencies (NumPy, SciPy, casatools) before using UVMultiFit.

This PR will change the `casa6` branch, which seems to be under development. If you do not want any changes by an external developer like me at this moment, please feel free to close the PR. (However, I would appreciate if you could keep this in mind for the future release!)